### PR TITLE
Rule 18.5.4.1 - EnableMulticast needs to be set to 1

### DIFF
--- a/tasks/section18.yml
+++ b/tasks/section18.yml
@@ -424,7 +424,7 @@
   ansible.windows.win_regedit:
       path: HKLM:\Software\Policies\Microsoft\Windows NT\DNSClient
       name: EnableMulticast
-      data: 0
+      data: 1
       type: dword
   when:
       - win16cis_rule_18_5_4_1


### PR DESCRIPTION
**Overall Review of Changes:**
The regkey "EnableMulticast" toggles the rule that disables multicast name resolution.

**Issue Fixes:**
"EnableMulticast" this setting needs to be set to 1 to disable multicast

**How has this been tested?:**
N/A

