### PR TITLE
(L1) Ensure 'Hardened UNC Paths' is set to 'Enabled, with "Require Mutual Authentication", "Require Integrity", and “Require Privacy” set for all NETLOGON and SYSVOL shares'

### DIFF
--- a/tasks/ansible_hardening/section18.yml
+++ b/tasks/ansible_hardening/section18.yml
@@ -741,14 +741,14 @@
       ansible.windows.win_regedit:
         path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\Networkprovider\Hardenedpaths
         name: "\\\\*\\NETLOGON"
-        data: "RequireMutualAuthentication=1, RequireIntegrity=1"
+        data: "RequireMutualAuthentication=1, RequireIntegrity=1, RequirePrivacy=1"
         type: string
 
     - name: "18.6.14.1 | PATCH | Ensure Hardened UNC Paths is set to Enabled with Require Mutual Authentication and Require Integrity set for all SYSVOL shares"
       ansible.windows.win_regedit:
         path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\Networkprovider\Hardenedpaths
         name: "\\\\*\\SYSVOL"
-        data: "RequireMutualAuthentication=1, RequireIntegrity=1"
+        data: "RequireMutualAuthentication=1, RequireIntegrity=1, RequirePrivacy=1"
         type: string
 
 - name: "18.6.19.2.1 | PATCH | Disable IPv6 Ensure TCPIP6 Parameter DisabledComponents is set to 0xff 255"


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
18.6.14.1 - (L1) Ensure 'Hardened UNC Paths' is set to 'Enabled, with "Require Mutual Authentication", "Require Integrity", and “Require Privacy” set for all NETLOGON and SYSVOL shares'

Only "Require Mutual Authentication", "Require Integrity" is set, missing "Require Privacy"

**Issue Fixes:**
Adding "Require Privacy"

**Enhancements:**
none

**How has this been tested?:**
Ran locally
