### PR TITLE
fix conditional for Ansible 2.19 and later

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
   ansible.builtin.assert:
     that:
       - ansible_os_family == 'Windows'
-      - ansible_distribution | regex_search('(Microsoft Windows Server 2016)')
+      - "'Microsoft Windows Server 2016' in ansible_distribution"
     success_msg: "{{ ansible_distribution }} {{ ansible_distribution_major_version }} is the detected operating system."
     fail_msg: "This role can only be run against Windows Server 2016 Editions. {{ ansible_distribution }} {{ ansible_distribution_major_version }} is not supported."
 


### PR DESCRIPTION
**Overall Review of Changes:**
Update the check against OS name to work with Ansible 2.19 and later

**Issue Fixes:**
- https://github.com/ansible-lockdown/Windows-11-CIS/issues/37

**How has this been tested?:**
Tested against Windows Server 2016 in AWX